### PR TITLE
test(streams): make publisher-autoscale integration spec deterministic under load

### DIFF
--- a/spec/integration/streams_pool_publisher_autoscale_spec.rb
+++ b/spec/integration/streams_pool_publisher_autoscale_spec.rb
@@ -60,51 +60,58 @@ RSpec.describe "Streams pool publisher autoscale", :integration do
       Thread.new do
         client.send(:with_streams_connection) do |_conn|
           held.count_down
-          release.pop
+          release.pop # nil on Queue#close — the cleanup wake-up
         end
       end
     end
-    expect(held.wait(5)).to be(true) # both holds established before the storm
 
-    # Saturate the remaining connection with a churn of concurrent publishers.
-    # Each send_stream_message fires the throttled trigger after producing.
     stop = Concurrent::AtomicBoolean.new(false)
     errors = Concurrent::Array.new
-    publishers = Array.new(8) do
-      Thread.new do
-        until stop.true?
-          begin
-            client.send_stream_message(stream_name, { "html" => "<x/>" })
-          rescue StandardError => e
-            errors << e
+    publishers = []
+    peak = 3
+    begin
+      expect(held.wait(5)).to be(true) # both holds established before the storm
+
+      # Saturate the remaining connection with a churn of concurrent publishers.
+      # Each send_stream_message fires the throttled trigger after producing.
+      publishers = Array.new(8) do
+        Thread.new do
+          until stop.true?
+            begin
+              client.send_stream_message(stream_name, { "html" => "<x/>" })
+            rescue StandardError => e
+              errors << e
+            end
           end
         end
       end
+
+      # Bounded growth window instead of a blind sample count: at the 0.05s
+      # autoscale interval this deadline covers ~300 check windows, and the loop
+      # breaks the moment growth lands (ResizablePool#swap publishes the new pool
+      # ref BEFORE draining the old one, so stats reflect it immediately).
+      deadline = monotonic_now + 15
+      while monotonic_now < deadline
+        # streams_pool_stats returns {} on a transient read hiccup (it rescues
+        # internally), and this loop runs concurrently with the swap storm — so
+        # size can be nil. Skip those samples rather than raise NoMethodError.
+        size = client.streams_pool_stats[:size]
+        peak = size if size && size > peak
+        break if peak > 3
+
+        sleep 0.05
+      end
+    ensure
+      # Always unwind, even when an expectation above raises — otherwise the
+      # holders block on release.pop forever, pinning pool checkouts while the
+      # after-hook closes the pool under them. Holders wake FIRST: they pin the
+      # old pool's in-flight counter, and the post-grow drain (bounded at
+      # streams_pool_timeout + 1) waits on it.
+      stop.make_true
+      release.close
+      holders.each { |t| t.join(5) }
+      publishers.each { |t| t.join(5) }
     end
-
-    # Bounded growth window instead of a blind sample count: at the 0.05s
-    # autoscale interval this deadline covers ~300 check windows, and the loop
-    # breaks the moment growth lands (ResizablePool#swap publishes the new pool
-    # ref BEFORE draining the old one, so stats reflect it immediately).
-    peak = 3
-    deadline = monotonic_now + 15
-    while monotonic_now < deadline
-      # streams_pool_stats returns {} on a transient read hiccup (it rescues
-      # internally), and this loop runs concurrently with the swap storm — so
-      # size can be nil. Skip those samples rather than raise NoMethodError.
-      size = client.streams_pool_stats[:size]
-      peak = size if size && size > peak
-      break if peak > 3
-
-      sleep 0.05
-    end
-
-    # Release the holders FIRST: they pin the old pool's in-flight counter, and
-    # the post-grow drain (bounded at streams_pool_timeout + 1) waits on it.
-    stop.make_true
-    2.times { release << :go }
-    holders.each { |t| t.join(5) }
-    publishers.each { |t| t.join(5) }
 
     expect(errors).to be_empty
     expect(peak).to be > 3           # the publish path grew the pool into headroom

--- a/spec/integration/streams_pool_publisher_autoscale_spec.rb
+++ b/spec/integration/streams_pool_publisher_autoscale_spec.rb
@@ -7,6 +7,16 @@ require "concurrent"
 # a broadcast storm, via the throttled trigger baked into send_stream_message
 # (issue #323 follow-up). No Streamer::Instance is created here — only a Client
 # publishing. Auto-skips without PGBUS_DATABASE_URL. Modest sizes.
+#
+# DETERMINISM (issue #400): growth requires busy_ratio >= 0.85, which at the
+# 3-connection baseline means ALL 3 connections checked out at the instant the
+# background check samples pool stats. Leaving that to publisher-thread timing
+# is scheduler luck — flaky on saturated CI runners. Instead the spec HOLDS 2 of
+# the 3 baseline connections checked out for the whole storm, so any single
+# in-flight publish saturates the pool; the storm then only has to keep the last
+# connection busy, which 8 hammering threads do near-continuously. The trigger
+# fires AFTER produce returns (the triggering publish never counts toward its
+# own check), so holding all 3 would deadlock publishing — 2 is the maximum.
 RSpec.describe "Streams pool publisher autoscale", :integration do
   let(:database_url) { ENV.fetch("PGBUS_DATABASE_URL") }
   let(:stream_name)  { "pas_#{SecureRandom.hex(4)}" }
@@ -19,7 +29,10 @@ RSpec.describe "Streams pool publisher autoscale", :integration do
       c.logger = Logger.new(IO::NULL)
       c.streams_pool_size = 3
       c.streams_pool_max = 8
-      c.streams_pool_timeout = 2
+      # 5s, not 2s: with 2 connections held, publishers rotate through a single
+      # connection — a slow runner's checkout waits must not brush the timeout
+      # and pollute the errors assertion.
+      c.streams_pool_timeout = 5
       c.streams_pool_autoscale = true
       # A short (but non-zero) interval so the storm triggers a few real checks
       # in-test without the 5-min production cadence. interval 0 would defeat the
@@ -34,9 +47,27 @@ RSpec.describe "Streams pool publisher autoscale", :integration do
   before { client.ensure_stream_queue(stream_name) }
   after  { client.close }
 
+  def monotonic_now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
   it "grows the streams pool from the publish path under a concurrent broadcast storm" do
-    # Saturate the streams pool with a churn of concurrent publishers. Each
-    # send_stream_message fires the throttled trigger after producing.
+    # Demand scaffolding: pin 2 of the 3 baseline connections as checked out.
+    # with_streams_connection is private — reached via #send because it is the
+    # only way to occupy streams-pool checkouts without booting a streamer; the
+    # behavior under test still flows through the public publish path.
+    held = Concurrent::CountDownLatch.new(2)
+    release = Queue.new
+    holders = Array.new(2) do
+      Thread.new do
+        client.send(:with_streams_connection) do |_conn|
+          held.count_down
+          release.pop
+        end
+      end
+    end
+    expect(held.wait(5)).to be(true) # both holds established before the storm
+
+    # Saturate the remaining connection with a churn of concurrent publishers.
+    # Each send_stream_message fires the throttled trigger after producing.
     stop = Concurrent::AtomicBoolean.new(false)
     errors = Concurrent::Array.new
     publishers = Array.new(8) do
@@ -51,28 +82,37 @@ RSpec.describe "Streams pool publisher autoscale", :integration do
       end
     end
 
-    # Sample the pool through the storm and track the peak size reached. A fast
-    # publish INSERT holds a connection only briefly, so the pool grows into
-    # headroom and (correctly) relaxes as the storm ebbs — the honest signal is
-    # that it grew ABOVE the baseline at some point and never exceeded the cap.
+    # Bounded growth window instead of a blind sample count: at the 0.05s
+    # autoscale interval this deadline covers ~300 check windows, and the loop
+    # breaks the moment growth lands (ResizablePool#swap publishes the new pool
+    # ref BEFORE draining the old one, so stats reflect it immediately).
     peak = 3
-    20.times do
-      sleep 0.1
+    deadline = monotonic_now + 15
+    while monotonic_now < deadline
       # streams_pool_stats returns {} on a transient read hiccup (it rescues
       # internally), and this loop runs concurrently with the swap storm — so
       # size can be nil. Skip those samples rather than raise NoMethodError.
       size = client.streams_pool_stats[:size]
-      next unless size
+      peak = size if size && size > peak
+      break if peak > 3
 
-      peak = size if size > peak
-      break if peak >= 8
+      sleep 0.05
     end
+
+    # Release the holders FIRST: they pin the old pool's in-flight counter, and
+    # the post-grow drain (bounded at streams_pool_timeout + 1) waits on it.
     stop.make_true
+    2.times { release << :go }
+    holders.each { |t| t.join(5) }
     publishers.each { |t| t.join(5) }
 
     expect(errors).to be_empty
     expect(peak).to be > 3           # the publish path grew the pool into headroom
     expect(peak).to be <= 8          # respected the hard cap
+    # swap_count increments only after the old pool's bounded drain completes on
+    # the trigger's executor thread — poll briefly rather than assert instantly.
+    swap_deadline = monotonic_now + config.streams_pool_timeout + 2
+    sleep 0.05 while client.streams_swap_stats.swap_count < 1 && monotonic_now < swap_deadline
     expect(client.streams_swap_stats.swap_count).to be >= 1
   end
 end


### PR DESCRIPTION
## Summary

Fixes the flaky `streams_pool_publisher_autoscale` integration spec (seen on PR #399, Integration PG 18, seed 43887) by replacing scheduler-luck demand with deterministic demand synchronization in `spec/integration/streams_pool_publisher_autoscale_spec.rb`.

**Root cause**: growth requires `busy_ratio >= 0.85` (`PoolAutoscaler#pool_busy`), which at the 3-connection baseline means **all 3** connections checked out at the exact instant the throttled background check samples `streams_pool_stats`. The old spec generated that saturation only via 8 publisher threads coinciding, and sampled a blind 20×0.1s window — on a saturated CI runner the coincidence may never happen inside 2 seconds.

**Fix** (per the issue's suggested direction — hold demand in-flight + bounded growth window):
- Pin 2 of the 3 baseline connections as held checkouts for the whole storm, so any single in-flight publish saturates the pool. Holding all 3 is impossible by design: the trigger fires *after* `produce` returns, so publishes would block on checkout and never fire it — 2 is the maximum, and 8 hammering publishers keep the last connection near-continuously busy.
- Replace the fixed sample count with a bounded 15s deadline (~300 check windows at the 0.05s autoscale interval) that breaks the moment growth lands (`ResizablePool#swap` publishes the new pool ref *before* draining the old one, so stats reflect growth immediately).
- `streams_pool_timeout` 2 → 5 in the spec config: with one usable connection, slow-runner checkout waits must not brush the timeout and pollute the `errors` assertion.
- `swap_count` is polled briefly instead of asserted instantly — it increments only after the old pool's bounded drain completes on the trigger's executor thread; holders are released first because they pin the old pool's in-flight counter.

Closes #400

## Test plan
- [x] `bundle exec rspec spec/integration/streams_pool_publisher_autoscale_spec.rb` — 5/5 consecutive green runs against a real DB
- [x] `bundle exec rubocop` on the changed file
- [ ] Integration CI legs green

## Deviations & judgment calls
- TDD RED step is the CI failure itself (PR #399 run 31612294828, seed 43887): the flake is scheduler-dependent and not deterministically reproducible locally, so no local RED reproduction was written; validation is 5 repeated green runs instead.
- Held connections use `client.send(:with_streams_connection)` (private API) — the only way to occupy streams-pool checkouts without booting a streamer; scaffolding only, the behavior under test still flows through the public publish path.
- Chose demand synchronization + bounded deadline over relaxing the `peak > 3` assertion, which would gut the test.
- No CHANGELOG entry: test-only change, no shipped behavior moved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `streams_pool_publisher_autoscale` integration spec deterministic under load and ensures holder cleanup even on failures to remove CI flakiness. The old spec depended on 3 concurrent checkouts within a 2s sample; the new spec pins 2 connections and uses a bounded deadline so any single publish triggers autoscale reliably.

- Hold 2 of the 3 baseline connections via `client.send(:with_streams_connection)`; cleanup (stop flag, `Queue#close` wake-up, thread joins) now runs in an ensure so holders always release before pool close/drain.
- Replace 20×0.1s sampling with a 15s deadline; exit as soon as pool size increases beyond the baseline.
- Increase `streams_pool_timeout` from 2s to 5s in test config to avoid false timeouts on slow runners.
- Poll `streams_swap_stats.swap_count` until it increments, since it updates after the old pool drains.
- Test-only change; no production behavior modified.

<sup>Written for commit 05183a8988cbd2e9d873beaaa6eeafa3a855cf15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoolutions/pgbus/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

