### PR TITLE
chore(lint): satisfy rubocop 1.90 Style/DirectiveScope

### DIFF
--- a/lib/pgbus/client.rb
+++ b/lib/pgbus/client.rb
@@ -1753,11 +1753,10 @@ module Pgbus
       timeout = config.read_timeout
       return mapping_statement_timeout(&block) unless timeout&.positive?
 
-      # rubocop:disable Pgbus/NoRubyTimeout -- deliberate last-resort bound; see above
+      # rubocop:disable-next Pgbus/NoRubyTimeout -- deliberate last-resort bound; see above
       Timeout.timeout(timeout + READ_TIMEOUT_SLACK, WedgedReadTimeout) do
         mapping_statement_timeout(&block)
       end
-      # rubocop:enable Pgbus/NoRubyTimeout
     rescue WedgedReadTimeout
       reload_pool_after_wedged_timeout
       raise

--- a/lib/pgbus/execution_pools/async_pool.rb
+++ b/lib/pgbus/execution_pools/async_pool.rb
@@ -95,7 +95,7 @@ module Pgbus
               "Add `gem \"async\"` to your Gemfile. Original error: #{e.message}"
       end
 
-      # rubocop:disable Lint/RescueException
+      # rubocop:disable-next Lint/RescueException
       def start_reactor
         Thread.new do
           Thread.current.name = "pgbus-async-reactor-#{object_id}"
@@ -122,7 +122,6 @@ module Pgbus
           raise
         end
       end
-      # rubocop:enable Lint/RescueException
 
       def wait_for_executions(semaphore)
         loop do

--- a/spec/pgbus/frozen_lockfile_sync_spec.rb
+++ b/spec/pgbus/frozen_lockfile_sync_spec.rb
@@ -9,7 +9,7 @@ require "spec_helper"
 # spec catches the drift directly — and in the normal rspec run, not just when a
 # frozen CI leg happens to fail. See #338 (the release-task sync) and its fix.
 #
-# rubocop:disable RSpec/DescribeClass -- a repo-hygiene guard, not a class under test
+# rubocop:disable-next RSpec/DescribeClass -- a repo-hygiene guard, not a class under test
 RSpec.describe "Frozen lockfile version sync" do
   %w[gemfiles/rails_7_1.gemfile.lock docs/Gemfile.lock].each do |relative|
     describe relative do
@@ -33,4 +33,3 @@ RSpec.describe "Frozen lockfile version sync" do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/pgbus/streams_spec.rb
+++ b/spec/pgbus/streams_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe Pgbus::Streams do
 
           def open?      = @open
           def closed?    = !@open
-          def after_commit(&block)   = @after_commit << block
+          def after_commit(&block) = @after_commit << block
           def after_rollback(&block) = @after_rollback << block
           def commit!    = @after_commit.each(&:call).then { @open = false }
           def rollback!  = @after_rollback.each(&:call).then { @open = false }


### PR DESCRIPTION
## Summary
- rubocop 1.90 (resolved from the unpinned `~> 1.21`) added `Style/DirectiveScope`; the Lint job has been red on `main` since (run on 20cc5ea) and blocks #440 and #441.
- Converted the three single-statement `disable`/`enable` pairs (`client.rb`, `async_pool.rb`, `frozen_lockfile_sync_spec.rb`) to `disable-next`; fixed one `Layout/SpaceAroundOperators` in `streams_spec.rb`. No behaviour change.

## Test plan
- [x] `bundle exec rubocop app benchmarks config gemfiles lib spec Gemfile Rakefile pgbus.gemspec` — no offenses
- [x] specs for the touched files: 353 examples, 0 failures
- [ ] CI Lint green

https://claude.ai/code/session_01Lfq49dVjiQEnoarpsWHqtv