### PR TITLE
chore(deploy): require dash 4.0.7 for the docs deploy

### DIFF
--- a/docs/config/deploy.yml
+++ b/docs/config/deploy.yml
@@ -7,7 +7,7 @@ image: zoolutions/pgbus
 
 # dash 4 renamed the on-host proxy (kamal-proxy → dash-proxy) and migrates a
 # host in place; an older CLI must not deploy this config.
-minimum_version: 4.0.0
+minimum_version: 4.0.7
 
 # A stateless docs site never rolls back far — keep the host tidy.
 retain_containers: 2


### PR DESCRIPTION
## Summary

dash [v4.0.7](https://github.com/zoolutions/dash/releases/tag/v4.0.7) is out with two deploy-path fixes (doctor passes a stale proxy the next deploy reboots automatically; registry login fails fast on a blank credential). Raise this docs site's dash floor to match: `minimum_version: 4.0.7` in `docs/config/deploy.yml`.

The shared deploy workflow (zoolutions/docs-kit#79) now installs `dash ~> 4.0.7`; this makes the site's own config state the same floor.

## Test plan

Config-only change — the docs redeploy after merge is the proof.

https://claude.ai/code/session_01KsqvKPn1c1hWu6NSEQHy1W


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the docs site's minimum `dash` version from 4.0.0 to 4.0.7, picking up two deploy-path fixes: doctor no longer passes a stale proxy that the next deploy reboots automatically, and registry login fails fast on a blank credential. The shared deploy workflow already installs `dash ~> 4.0.7`, so this keeps the site's config aligned.

<sup>Written for commit 835e7a54e52e0700b6dd80953420a7d97c07947f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoolutions/pgbus/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

