### PR TITLE
chore: add bin/release to pick the next version and drive rake release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ bundle exec rake bench:one[client_bench]  # Single benchmark by name
 bundle exec rake bench:memory             # Detailed memory profiling
 bundle exec rake bench:integration        # Real DB benchmarks (requires PGBUS_DATABASE_URL)
 bundle exec rake bench:streams            # SSE streaming benchmarks (requires PGBUS_DATABASE_URL)
+bin/release list                          # Last releases + next patch/minor/major version
+bin/release [minor|major|X.Y.Z] [-n]      # Cut a release (patch by default) via rake release; -n = dry run
 ```
 
 ## Slash Commands

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Cut a pgbus release. Works out the next version, shows what is about to
+# ship, and hands off to `rake release[X.Y.Z]`, which bumps
+# lib/pgbus/version.rb + the three frozen lockfile pins, commits, pushes
+# main, and publishes the GitHub Release that triggers the RubyGems publish.
+#
+#   bin/release            # patch bump for a bugfix  (0.15.4 -> 0.15.5)
+#   bin/release minor      # 0.15.4 -> 0.16.0
+#   bin/release major      # 0.15.4 -> 1.0.0
+#   bin/release 0.16.0     # explicit version (v-prefix optional)
+#   bin/release list       # last releases + what each bump would give
+#   bin/release --dry-run  # (-n) show version + changes, publish nothing
+#   bin/release --force    # (-f) re-create an existing tag/release
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BUMP="patch"
+DRY_RUN=false
+FORCE=false
+LIST=false
+EXPLICIT=""
+
+for arg in "$@"; do
+  case "$arg" in
+    major|minor|patch) BUMP="$arg" ;;
+    list|--list|-l) LIST=true ;;
+    v[0-9]*|[0-9]*.[0-9]*) EXPLICIT="${arg#v}" ;;
+    --dry-run|-n) DRY_RUN=true ;;
+    --force|-f) FORCE=true ;;
+    -h|--help) sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $arg (try --help)" >&2; exit 1 ;;
+  esac
+done
+
+git fetch -q origin main --tags
+
+# lib/pgbus/version.rb is what rake release bumps and what the gem ships, so
+# it is the source of truth; the newest v* tag should agree with it.
+CURRENT=$(ruby -e 'require "./lib/pgbus/version"; puts Pgbus::VERSION')
+LAST_TAG=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)
+
+IFS=. read -r MAJOR MINOR PATCH <<< "$CURRENT"
+MAJOR=${MAJOR:-0}; MINOR=${MINOR:-0}; PATCH=${PATCH%%[^0-9]*}; PATCH=${PATCH:-0}
+
+next_version() {
+  case "$1" in
+    major) echo "$((MAJOR + 1)).0.0" ;;
+    minor) echo "${MAJOR}.$((MINOR + 1)).0" ;;
+    patch) echo "${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+  esac
+}
+
+if $LIST; then
+  echo "current version: $CURRENT  (lib/pgbus/version.rb)"
+  echo
+  echo "last releases:"
+  git for-each-ref --sort=-v:refname --count=5 \
+    --format='  %(refname:short)  %(creatordate:short)' 'refs/tags/v[0-9]*'
+  echo
+  echo "next version:"
+  printf '  %-6s v%s\n' patch "$(next_version patch)" minor "$(next_version minor)" major "$(next_version major)"
+  exit 0
+fi
+
+if [ -n "$EXPLICIT" ]; then
+  NEXT="$EXPLICIT"; HOW="explicit"
+else
+  NEXT=$(next_version "$BUMP"); HOW="$BUMP"
+fi
+TAG="v$NEXT"
+SHA=$(git rev-parse HEAD)
+REMOTE_SHA=$(git rev-parse origin/main)
+
+echo "current:  $CURRENT  (last tag: ${LAST_TAG:-none})"
+echo "release:  $TAG  ($HOW)"
+echo "target:   $(git branch --show-current) @ ${SHA:0:8}"
+echo
+echo "changes since ${LAST_TAG:-repository start}:"
+git log --oneline --no-decorate "${LAST_TAG:+$LAST_TAG..}HEAD" | sed 's/^/  /'
+echo
+
+if [ -n "$LAST_TAG" ] && [ "$LAST_TAG" != "v$CURRENT" ]; then
+  echo "warning: lib/pgbus/version.rb says $CURRENT but the newest tag is $LAST_TAG" >&2
+fi
+
+if $DRY_RUN; then
+  echo "dry run — nothing bumped or published"
+  exit 0
+fi
+
+# rake release commits the bump and pushes origin main, so it must start from
+# a clean, up-to-date main — otherwise the push either fails or ships
+# whatever local commits happen to be sitting there.
+[ "$(git branch --show-current)" = "main" ] || { echo "run bin/release from main (on $(git branch --show-current))" >&2; exit 1; }
+[ -z "$(git status --porcelain)" ] || { echo "working tree has uncommitted changes; commit or stash first" >&2; exit 1; }
+[ "$SHA" = "$REMOTE_SHA" ] || { echo "local main (${SHA:0:8}) != origin/main (${REMOTE_SHA:0:8}); run: git pull --ff-only origin main" >&2; exit 1; }
+if ! $FORCE && git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  echo "tag $TAG already exists (pass --force to re-create it)" >&2
+  exit 1
+fi
+
+read -r -p "bump to $NEXT, push main and publish $TAG to GitHub + RubyGems? [y/N] " answer
+[[ "$answer" =~ ^[Yy]$ ]] || { echo "aborted"; exit 1; }
+
+if $FORCE; then
+  exec bundle exec rake "release[$NEXT,force]"
+else
+  exec bundle exec rake "release[$NEXT]"
+fi


### PR DESCRIPTION
## Summary

A cosmos-style `bin/release` for pgbus. It does **not** replace `rake release[X.Y.Z]` — that task owns the version-file bump, the surgical pin bump in the three frozen lockfiles, the commit, the push and the GitHub Release (→ RubyGems). `bin/release` is the front end that answers "what's the last release and what's next?" and picks the version so nobody has to type it:

```
$ bin/release list
current version: 0.15.4  (lib/pgbus/version.rb)

last releases:
  v0.15.4  2026-08-31
  v0.15.3  2026-08-31
  ...

next version:
  patch  v0.15.5
  minor  v0.16.0
  major  v1.0.0

$ bin/release -n            # patch by default (the bugfix bump); also: minor | major | 0.16.0
current:  0.15.4  (last tag: v0.15.4)
release:  v0.15.5  (patch)
target:   main @ e0e447d9

changes since v0.15.4:
  e0e447d fix(uniqueness): reaper ignores dead-letter queues when probing unbound locks (#450)

dry run — nothing bumped or published
```

Without `-n` it confirms, then `exec bundle exec rake "release[X.Y.Z]"` (`--force` → `release[X.Y.Z,force]`).

Guards before the real run: on `main`, clean tree, `HEAD == origin/main` (rake pushes `origin main`, so stale local main would ship stray commits or fail the push), tag not already present unless `--force`. Warns when `lib/pgbus/version.rb` and the newest `v*` tag disagree.

`CLAUDE.md` commands block lists the two forms.

## Test plan

- [x] `bin/release list`, `bin/release -n`, `bin/release minor -n`, `bin/release v1.0.0 -n`, `bin/release 0.16.0 -n`, `--help`, unknown arg (exit 1), off-main guard (exit 1) — all exercised locally
- [ ] Next real bugfix release: `bin/release` from main, confirm it drops into `rake release[0.15.5]` and the release workflow runs as before

## Deviations & judgment calls

- **Version source is `lib/pgbus/version.rb`, not the newest tag** (cosmos uses tags). That is what `rake release` bumps and the gem ships; the script cross-checks the tag and warns on disagreement instead of silently trusting either.
- **Default bump is `patch`** — the semver bump for a bugfix (0.15.4 → 0.15.5). `minor` is there for feature releases. If "bump a minor for a bugfix" meant you want `minor` as the default, it's a one-word change in the script.
- The real run requires being on `main` and in sync with `origin/main`; dry-run and `list` work from any branch.
- No CHANGELOG entry — tooling only, nothing in the gem changes.

https://claude.ai/code/session_01GcC2ppKrFHhk9Wk2gqDM5A


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `bin/release`, a front-end for the existing `rake release` task that picks the next version instead of requiring it to be typed. It shows the current version, the last few tags, and the commits since the last tag, then defaults to a patch bump and hands off to `rake release[X.Y.Z]`; that task still owns the version bump, frozen-lockfile pins, commit, push, and GitHub Release. `-n` previews without bumping or publishing, and `list` shows each bump level that would result.

**Guards**
- Real runs require a clean tree on `main` with `HEAD` in sync with `origin/main`.
- Refuses to re-create an existing tag unless `--force` is passed.
- Warns when `lib/pgbus/version.rb` disagrees with the newest `v*` tag.
- Nothing in the gem itself changes; this is tooling only, so no CHANGELOG entry.

<sup>Written for commit 8dd4c2b1d8e53ee0240fbb9bbc7d307f6e64e836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoolutions/pgbus/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

