### PR TITLE
chore(deps): pgmq-ruby 0.7.2 + green bare rspec run

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,8 +237,8 @@ GEM
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
-    pgmq-ruby (0.7.1)
-      connection_pool (~> 2.4)
+    pgmq-ruby (0.7.2)
+      connection_pool (>= 2.4, < 4)
       pg (~> 1.5)
       zeitwerk (~> 2.6)
     phlex (2.4.1)
@@ -524,7 +524,7 @@ CHECKSUMS
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
   pgbus (0.15.4)
-  pgmq-ruby (0.7.1) sha256=d5057dd16fb2bc2668978a942809749b4a27092ff92c904fc96ebab5ebc418f5
+  pgmq-ruby (0.7.2) sha256=b9ffcc9b8d63d85709ae075f0e71082f74aaa1f515bf41da88fdc8777a78bfcb
   phlex (2.4.1) sha256=e596717fbfe38b5271840266758779ebe75092e02629f0c170287e6290a70b12
   phlex-rails (2.4.0) sha256=2bcddbd488681acb25753bab1887d3ac150e644244ff8ba307f2171a4d0195f5
   playwright-ruby-client (1.58.1) sha256=0678b227eb469c551858784441891577b402163e9b2d50bddce4a5a904e3a5ca

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -22,6 +22,7 @@ search:
   exclude:
     - "*.md"
     - app/assets/images
+    - app/frontend/pgbus/vendor
   strict: false
 
 translation:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -168,8 +168,6 @@ da:
         reroute_failed: Kunne ikke omdirigere begivenhed.
         rerouted: Begivenhed omdirigeret til målhandler.
       index:
-        discard_all: Forkast alle
-        discard_all_confirm: Forkast alle ventende begivenheder? Dette kan ikke fortrydes.
         discard_selected: Forkast valgte
         discard_selected_confirm: Forkast valgte begivenheder?
         pending_empty: Ingen ventende begivenheder

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -168,8 +168,6 @@ de:
         reroute_failed: Ereignis konnte nicht umgeleitet werden.
         rerouted: Ereignis an Ziel-Handler umgeleitet.
       index:
-        discard_all: Alle verwerfen
-        discard_all_confirm: Alle ausstehenden Ereignisse verwerfen? Dies kann nicht rückgängig gemacht werden.
         discard_selected: Ausgewählte verwerfen
         discard_selected_confirm: Ausgewählte Ereignisse verwerfen?
         pending_empty: Keine ausstehenden Ereignisse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,8 +168,6 @@ en:
         reroute_failed: Could not reroute event.
         rerouted: Event rerouted to target handler.
       index:
-        discard_all: Discard All
-        discard_all_confirm: Discard all pending events? This cannot be undone.
         discard_selected: Discard Selected
         discard_selected_confirm: Discard selected events?
         pending_empty: No pending events

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -168,8 +168,6 @@ es:
         reroute_failed: No se pudo redirigir el evento.
         rerouted: Evento redirigido al manejador objetivo.
       index:
-        discard_all: Descartar todo
-        discard_all_confirm: "¿Descartar todos los eventos pendientes? Esto no se puede deshacer."
         discard_selected: Descartar seleccionados
         discard_selected_confirm: "¿Descartar eventos seleccionados?"
         pending_empty: No hay eventos pendientes

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -168,8 +168,6 @@ fi:
         reroute_failed: Tapahtumaa ei voitu uudelleenreitittää.
         rerouted: Tapahtuma uudelleenreititetty kohdekäsittelijälle.
       index:
-        discard_all: Hylkää kaikki
-        discard_all_confirm: Hylätäänkö kaikki odottavat tapahtumat? Tätä ei voi peruuttaa.
         discard_selected: Hylkää valitut
         discard_selected_confirm: Hylätäänkö valitut tapahtumat?
         pending_empty: Ei odottavia tapahtumia

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -168,8 +168,6 @@ fr:
         reroute_failed: Impossible de rediriger l'événement.
         rerouted: Événement redirigé vers le gestionnaire cible.
       index:
-        discard_all: Tout jeter
-        discard_all_confirm: Jeter tous les événements en attente ? Cette action est irréversible.
         discard_selected: Jeter la sélection
         discard_selected_confirm: Jeter les événements sélectionnés ?
         pending_empty: Aucun événement en attente

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -168,8 +168,6 @@ it:
         reroute_failed: Impossibile reindirizzare l'evento.
         rerouted: Evento reindirizzato al gestore di destinazione.
       index:
-        discard_all: Scarta tutto
-        discard_all_confirm: Scartare tutti gli eventi in sospeso? Questa operazione non può essere annullata.
         discard_selected: Scarta selezionati
         discard_selected_confirm: Scartare gli eventi selezionati?
         pending_empty: Nessun evento in sospeso

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -168,8 +168,6 @@ ja:
         reroute_failed: イベントをルーティングできませんでした。
         rerouted: イベントがターゲットハンドラーにルーティングされました。
       index:
-        discard_all: すべて破棄
-        discard_all_confirm: 保留中のすべてのイベントを破棄しますか？これは元に戻せません。
         discard_selected: 選択を破棄
         discard_selected_confirm: 選択したイベントを破棄しますか？
         pending_empty: 保留中のイベントはありません

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -168,8 +168,6 @@ nb:
         reroute_failed: Kunne ikke omdirigere hendelse.
         rerouted: Hendelse omdirigert til målbehandler.
       index:
-        discard_all: Forkast alle
-        discard_all_confirm: Forkast alle ventende hendelser? Dette kan ikke angres.
         discard_selected: Forkast valgte
         discard_selected_confirm: Forkast valgte hendelser?
         pending_empty: Ingen ventende hendelser

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -168,8 +168,6 @@ nl:
         reroute_failed: Kon gebeurtenis niet omleiden.
         rerouted: Gebeurtenis omgeleid naar doelhandler.
       index:
-        discard_all: Alles Verwijderen
-        discard_all_confirm: Alle openstaande gebeurtenissen verwijderen? Dit kan niet ongedaan worden gemaakt.
         discard_selected: Geselecteerde Verwijderen
         discard_selected_confirm: Geselecteerde gebeurtenissen verwijderen?
         pending_empty: Geen openstaande gebeurtenissen

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -168,8 +168,6 @@ pt:
         reroute_failed: Não foi possível redirecionar o evento.
         rerouted: Evento redirecionado para o manipulador alvo.
       index:
-        discard_all: Descartar Todos
-        discard_all_confirm: Descartar todos os eventos pendentes? Esta ação não pode ser desfeita.
         discard_selected: Descartar Selecionados
         discard_selected_confirm: Descartar eventos selecionados?
         pending_empty: Nenhum evento pendente

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -168,8 +168,6 @@ sv:
         reroute_failed: Kunde inte omdirigera händelsen.
         rerouted: Händelsen omdirigerades till målhanteraren.
       index:
-        discard_all: Kassera alla
-        discard_all_confirm: Kassera alla väntande händelser? Detta kan inte ångras.
         discard_selected: Kassera valda
         discard_selected_confirm: Kassera valda händelser?
         pending_empty: Inga väntande händelser

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -211,8 +211,8 @@ GEM
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
-    pgmq-ruby (0.7.1)
-      connection_pool (~> 2.4)
+    pgmq-ruby (0.7.2)
+      connection_pool (>= 2.4, < 4)
       pg (~> 1.5)
       zeitwerk (~> 2.6)
     phlex (2.4.1)
@@ -503,7 +503,7 @@ CHECKSUMS
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
   pgbus (0.15.4)
-  pgmq-ruby (0.7.1) sha256=d5057dd16fb2bc2668978a942809749b4a27092ff92c904fc96ebab5ebc418f5
+  pgmq-ruby (0.7.2) sha256=b9ffcc9b8d63d85709ae075f0e71082f74aaa1f515bf41da88fdc8777a78bfcb
   phlex (2.4.1) sha256=e596717fbfe38b5271840266758779ebe75092e02629f0c170287e6290a70b12
   phlex-rails (2.4.0) sha256=2bcddbd488681acb25753bab1887d3ac150e644244ff8ba307f2171a4d0195f5
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570

--- a/docs/app/models/config_reference.rb
+++ b/docs/app/models/config_reference.rb
@@ -37,7 +37,9 @@ module ConfigReference
       { name: "execution_mode", type: "Symbol", default: ":threads", desc: "Global execution mode (:threads or :async)." },
       { name: "polling_interval", type: "Numeric", default: "0.1", desc: "Seconds between polls (LISTEN/NOTIFY is primary)." },
       { name: "prefetch_limit", type: "Integer, nil", default: "nil", desc: "Max in-flight messages per worker." },
-      { name: "visibility_timeout", type: "Duration", default: "30", desc: "How long a read message stays invisible before retry." }
+      { name: "visibility_timeout", type: "Duration", default: "30", desc: "How long a read message stays invisible before retry." },
+      { name: "visibility_heartbeat", type: "Boolean", default: "true", desc: "Re-arm a running job's visibility timeout on a heartbeat so a job that outlives it is not redelivered (and eventually dead-lettered) mid-run; the timeout then only fires for a process that is gone. false restores plain PGMQ semantics." },
+      { name: "visibility_heartbeat_interval", type: "Duration, nil", default: "nil (visibility_timeout / 3)", desc: "Seconds between heartbeat re-arms of a running job's message." }
     ],
     "Worker recycling" => [
       { name: "max_jobs_per_worker", type: "Integer, nil", default: "nil", desc: "Recycle a worker after N jobs." },

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -246,8 +246,8 @@ GEM
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
-    pgmq-ruby (0.7.1)
-      connection_pool (~> 2.4)
+    pgmq-ruby (0.7.2)
+      connection_pool (>= 2.4, < 4)
       pg (~> 1.5)
       zeitwerk (~> 2.6)
     phlex (2.4.1)
@@ -550,7 +550,7 @@ CHECKSUMS
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
   pgbus (0.15.4)
-  pgmq-ruby (0.7.1) sha256=d5057dd16fb2bc2668978a942809749b4a27092ff92c904fc96ebab5ebc418f5
+  pgmq-ruby (0.7.2) sha256=b9ffcc9b8d63d85709ae075f0e71082f74aaa1f515bf41da88fdc8777a78bfcb
   phlex (2.4.1) sha256=e596717fbfe38b5271840266758779ebe75092e02629f0c170287e6290a70b12
   phlex-rails (2.4.0) sha256=2bcddbd488681acb25753bab1887d3ac150e644244ff8ba307f2171a4d0195f5
   playwright-ruby-client (1.58.1) sha256=0678b227eb469c551858784441891577b402163e9b2d50bddce4a5a904e3a5ca

--- a/spec/rubocop/cop/pgbus/no_ruby_timeout_spec.rb
+++ b/spec/rubocop/cop/pgbus/no_ruby_timeout_spec.rb
@@ -2,10 +2,21 @@
 
 require "spec_helper"
 require "rubocop"
-require "rubocop/rspec/support"
-require "rubocop/pgbus"
+# Require RuboCop's test-support pieces individually instead of
+# "rubocop/rspec/support": that file calls RSpec.configure and includes
+# CopHelper into EVERY example group, whose #registry/#config methods shadow
+# pgbus specs' own lets and break unrelated specs in a bare full-suite run.
+require "rubocop/rspec/cop_helper"
+require "rubocop/rspec/expect_offense"
+require "rubocop/rspec/shared_contexts"
+require_relative "../../../../rubocop/pgbus"
 
-RSpec.describe RuboCop::Cop::Pgbus::NoRubyTimeout, :config do
+RSpec.describe RuboCop::Cop::Pgbus::NoRubyTimeout do
+  include CopHelper
+  include RuboCop::RSpec::ExpectOffense
+
+  include_context "config"
+
   let(:config) { RuboCop::Config.new }
 
   it "flags Timeout.timeout" do


### PR DESCRIPTION
## Summary
- **pgmq-ruby 0.7.1 → 0.7.2** locked in all three tracked lockfiles (`Gemfile.lock`, `gemfiles/rails_7_1.gemfile.lock`, `docs/Gemfile.lock`) via `bundle update pgmq-ruby --conservative`. Changelog reviewed: 0.7.2's only change loosens pgmq-ruby's `connection_pool` dependency from `~> 2.4` to `>= 2.4, < 4` — no API changes, nothing to adopt in pgbus code. The gemspec's `~> 0.7.1` constraint already admits it, so no gemspec change; `connection_pool` stays resolved at 2.5.5.
- **Bare full-suite `bundle exec rspec` is green again** (fixed as found, per "we fix failures as we find them"). CI only runs `spec/pgbus/ spec/generators/` (+ integration/system legs), so these were local-only:
  - `spec/rubocop/cop/pgbus/no_ruby_timeout_spec.rb` — `require "rubocop/pgbus"` LoadError (repo root isn't on `$LOAD_PATH`) → `require_relative`. That exposed the real reason the dir was quarantined: `require "rubocop/rspec/support"` globally includes RuboCop's `CopHelper` into every example group, whose `#registry`/`#config` shadow pgbus specs' lets — 147 order-dependent failures in a bare run. Now requires `cop_helper`/`expect_offense`/`shared_contexts` individually and includes them only inside the cop spec's own example group.
  - `spec/i18n_spec.rb` — i18n-tasks crashed scanning vendored `app/frontend/pgbus/vendor/apexcharts.js`; the vendor dir is now excluded in `config/i18n-tasks.yml`. The fixed scan surfaced 24 genuinely dead keys (`pgbus.events.index.discard_all(_confirm)` × 12 locales, orphaned since the events page moved to checkbox "Discard Selected" in #57 — no route or controller action remains) — removed via `i18n-tasks remove-unused`.

Closes #449

## Test plan
- [x] `bundle exec rspec` — bare, no exclude pattern: **4782 examples, 0 failures** (previously: load abort, or 2 failures with `spec/rubocop` excluded)
- [x] `bundle exec rspec spec/rubocop` in isolation: 5 examples, 0 failures
- [x] `bundle exec rubocop`: 603 files, no offenses
- [x] Lockfile diffs are exactly the pgmq-ruby 3 lines per file (version, dep constraint, checksum) — nothing else resolved differently

## Deviations & judgment calls
- Discovery: issue text says the gemspec pins `~> 0.7.0`; it actually pins `~> 0.7.1` (bumped in #355). 0.7.2 satisfies it either way — no gemspec change needed.
- Judgment call: no CHANGELOG entry — lockfile-only dev-dependency refresh; gem consumers resolve by the unchanged gemspec constraint, so nothing user-facing moved.
- Judgment call: no TDD RED test for the bump itself — no pgbus code changes; the full suite is the regression net. For the suite fixes, the pre-existing failures were the RED state.
- Scope extension (user-directed mid-task): fixing the three pre-existing bare-run spec failures described above, including deleting the 24 dead locale keys rather than ignoring them in `i18n-tasks.yml`.
- Residual global effect knowingly kept: requiring RuboCop's `shared_contexts.rb` adds one global `before { RuboCop::PathUtil.reset_pwd }` hook — it only clears a memoized `Dir.pwd`, harmless to other specs.

https://claude.ai/code/session_01GcC2ppKrFHhk9Wk2gqDM5A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `pgmq-ruby` to 0.7.2 and fixes three pre-existing spec failures so a bare `bundle exec rspec` runs green. Closes #449.

**Dependencies**
- 0.7.2 only loosens `connection_pool` from `~> 2.4` to `>= 2.4, < 4`, so no pgbus code changes were needed.
- Lockfile-only refresh across all three tracked lockfiles; `connection_pool` remains at 2.5.5.

**Bug Fixes**
- `no_ruby_timeout_spec.rb` loaded RuboCop's shared support into every example group, shadowing pgbus specs' lets; it now requires the helpers individually and includes them only in the cop spec.
- `i18n-tasks` crashed scanning `app/frontend/pgbus/vendor/apexcharts.js`, which is now excluded; the fixed scan surfaced 24 dead locale keys (`discard_all` and `discard_all_confirm` across 12 locales) that were removed.
- Added the missing `visibility_heartbeat` and `visibility_heartbeat_interval` entries to the config reference; docs CI fails without them.

<sup>Written for commit c492410ff1ee4c3c391979391d36c604f6ba5449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoolutions/pgbus/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

